### PR TITLE
Retrieve VOs from token

### DIFF
--- a/ai4eosc/main.py
+++ b/ai4eosc/main.py
@@ -2,13 +2,15 @@
 Create an app with FastAPI
 """
 
+from typing import Optional
+
 from fastapi import Depends, FastAPI, Request, Response
 from fastapi.security import HTTPBearer
 
 # from ai4eosc.dependencies import get_query_token, get_token_header
 # from .internal import admin
 
-from ai4eosc.auth import init_flaat, flaat, get_owner
+from ai4eosc.auth import init_flaat, flaat, get_user_info
 from ai4eosc.routers import deployments, info, modules
 
 
@@ -37,8 +39,8 @@ init_flaat()
 def root(
     authorization=Depends(security),
     ):
-    sub, iss = get_owner(token=authorization.credentials)
-    return f"This is the AI4EOSC project's API currently used by {sub}@{iss}."
+    user = get_user_info(token=authorization.credentials)
+    return f"This is the AI4EOSC project's API. Current authenticated user: {user}"
 
 
 if __name__ == "__main__":

--- a/ai4eosc/routers/deployments.py
+++ b/ai4eosc/routers/deployments.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import HTTPBearer
 import nomad
 
-from ai4eosc.auth import get_owner
+from ai4eosc.auth import get_user_info
 from ai4eosc.conf import NOMAD_JOB_CONF, USER_CONF_VALUES
 # from ai4eosc.dependencies import get_token_header
 
@@ -46,7 +46,7 @@ def get_deployments(
     
     Returns a list of deployments.
     """
-    owner, _  = get_owner(token=authorization.credentials)
+    user = get_user_info(token=authorization.credentials)
     jobs = Nomad.jobs.get_jobs()  # job summaries
 
     # Filter jobs
@@ -135,8 +135,8 @@ def create_deployment(
     Returns a dict with status
     """
     # Enforce job owner
-    owner, _  = get_owner(token=authorization.credentials)
-    if not owner:
+    user = get_user_info(token=authorization.credentials)
+    if not user:
         raise ValueError("You must provide a owner of the deployment. For testing purposes you can use 'janedoe'.")
     
     # Enforce JupyterLab password minimum number of characters
@@ -219,8 +219,8 @@ def delete_deployment(
     """
 
     # Enforce job owner
-    owner, _ = get_owner(token=authorization.credentials)
-    if not owner:
+    user = get_user_info(token=authorization.credentials)
+    if not user:
         raise ValueError("You must provide a owner of the deployment. For testing purposes you can use 'janedoe'.")
 
     # Check the deployment exists and belongs to the user

--- a/etc/main_conf.yaml
+++ b/etc/main_conf.yaml
@@ -13,24 +13,6 @@ auth:
     - https://aai-dev.egi.eu/oidc
     - https://aai.egi.eu/oidc/
     - https://aai.egi.eu/auth/realms/egi
-    - https://accounts.google.com/
-    - https://b2access-integration.fz-juelich.de/oauth2
-    - https://b2access.eudat.eu/oauth2/
-    - https://iam-test.indigo-datacloud.eu/
-    - https://iam.deep-hybrid-datacloud.eu/
-    - https://iam.extreme-datacloud.eu/
-    - https://login-dev.helmholtz.de/oauth2/
-    - https://login.elixir-czech.org/oidc/
-    - https://login.helmholtz-data-federation.de/oauth2/
-    - https://login.helmholtz.de/oauth2/
-    - https://oidc.scc.kit.edu/auth/realms/kit/
-    - https://orcid.org/
-    - https://proxy.demo.eduteams.org
-    - https://services.humanbrainproject.eu/oidc/
-    - https://unity.eudat-aai.fz-juelich.de/oauth2/
-    - https://unity.helmholtz-data-federation.de/oauth2/
-    - https://wlcg.cloud.cnaf.infn.it/
-    - https://proxy.eduteams.org/
 
   VO:  # Virtual Organizations
 


### PR DESCRIPTION
Take into account that:
* I removed support for DEEP IAM because it does not support VOs.
We could potentially handle that corner case and make DEEP-IAM users to deploy in the ai4eosc namespace. But the code will eventually get dirty as we would need to check that DEEP-IAM IDs do not clash with EGI IDs and so on. I would rather start from a nice foundation and only support EGI Checkin, which will be anyways the default authentication method for the project.

* You have to enable the `eduperson_entitlement` scope to access the VOs, so you might need to reconfigure your oidc-agent for EGI Checkin.
https://github.com/AI4EOSC/ai4-lib/tree/auth#generate-a-token-via-the-terminal
Or you could use EGI Checkin UI to get the token:
https://github.com/AI4EOSC/ai4-lib/tree/auth#generate-a-token-with-a-ui